### PR TITLE
Fix for  AAPT: Apostrophe not preceded by

### DIFF
--- a/res/values-fr/appupdate_strings.xml
+++ b/res/values-fr/appupdate_strings.xml
@@ -12,6 +12,6 @@
     <string name="download_complete_neu_btn">Installer manuelle</string>
 
     <string name="update_error_title">Erreur</string>
-    <string name="update_error_message">Le réseau  n'est pas disponible pour l'instant, vérifiez les paramètres de votre réseau。</string>
-    <string name="update_error_yes_btn">C'est noté</string>
+    <string name="update_error_message">Le réseau  n\'est pas disponible pour l\'instant, vérifiez les paramètres de votre réseau。</string>
+    <string name="update_error_yes_btn">C\'est noté</string>
 </resources>


### PR DESCRIPTION
 Error: cmd: Command failed with exit code 1 Error output:
       merged\armv7\release\values-fr\values-fr.xml:64:
        AAPT: Apostrophe not preceded by \ (in Le r�seau  n'est pas disponible pour l'instant, v�rifiez les param�tres
        de votre r�seau?)

        \armv7\release\values-fr\values-fr.xml:66:
        AAPT: Apostrophe not preceded by \ (in C'est not�)

        d\armv7\release\values-fr\values-fr.xml:64:
        error: Apostrophe not preceded by \ (in Le r�seau  n'est pas disponible pour l'instant, v�rifiez les param�tres
        de votre r�seau?)