### PR TITLE
Prevent INSTALL_FAILED_CONFLICTING_PROVIDER error

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -26,7 +26,7 @@
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
              <provider
                 android:name="com.vaenow.appupdate.android.GenericFileProvider"
-                android:authorities="com.vaenow.appupdate.android.provider"
+                android:authorities="com.vaenow.appupdate.android.provider.${applicationId}"
                 android:exported="false"
                 android:grantUriPermissions="true">
                 <meta-data


### PR DESCRIPTION
This happens when installing multiple apps that use this plugin.

This was solved by adding ${applicationId} to the android:authorities
property, to make each provider unique. It is a standard solution also
used in other official cordova plugins.