### PR TITLE
Fix issue with updating when targeting Nougat or higher

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -26,7 +26,7 @@
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
              <provider
                 android:name="com.vaenow.appupdate.android.GenericFileProvider"
-                android:authorities="com.vaenow.appupdate.android.provider.${applicationId}"
+                android:authorities="com.vaenow.appupdate.android.provider"
                 android:exported="false"
                 android:grantUriPermissions="true">
                 <meta-data

--- a/src/android/AuthenticationOptions.java
+++ b/src/android/AuthenticationOptions.java
@@ -1,0 +1,65 @@
+package android;
+
+
+import android.util.Base64;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.nio.charset.StandardCharsets;
+
+public class AuthenticationOptions {
+
+    private String authType;
+    private String username;
+    private String password;
+
+    public AuthenticationOptions(JSONObject options) {
+        try {
+            this.setAuthType(options.getString("authType"));
+            this.setUsername(options.getString("username"));
+            this.setPassword(options.getString("password"));
+        } catch (JSONException e){
+            // If there is any error then ensure that auth type is unset
+            this.setAuthType("");
+        }
+    }
+
+    /**
+     * Flag indicating authentication credentials have been set
+     *
+     * @return boolean flag indicating if there are authentication credentials
+     */
+    public boolean hasCredentials() {
+        return authType.equals("basic");
+    }
+
+    public String getEncodedAuthorization() {
+        return "Basic " + Base64.encodeToString((this.username + ":" + this.password)
+                .getBytes(StandardCharsets.UTF_8), Base64.DEFAULT);
+    }
+
+    public String getAuthType() {
+        return authType;
+    }
+
+    public void setAuthType(String authType) {
+        this.authType = authType;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/android/DownloadApkThread.java
+++ b/src/android/DownloadApkThread.java
@@ -1,5 +1,6 @@
 package com.vaenow.appupdate.android;
 
+import android.AuthenticationOptions;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.os.Environment;
@@ -37,13 +38,13 @@ public class DownloadApkThread implements Runnable {
     private AlertDialog mDownloadDialog;
     private DownloadHandler downloadHandler;
     private Handler mHandler;
-    private JSONObject options;
+    private AuthenticationOptions authentication;
 
     public DownloadApkThread(Context mContext, Handler mHandler, ProgressBar mProgress, AlertDialog mDownloadDialog, HashMap<String, String> mHashMap, JSONObject options) {
         this.mDownloadDialog = mDownloadDialog;
         this.mHashMap = mHashMap;
         this.mHandler = mHandler;
-        this.options = options;
+        this.authentication = new AuthenticationOptions(options);
 
         this.mSavePath = Environment.getExternalStorageDirectory() + "/" + "download"; // SD Path
         this.downloadHandler = new DownloadHandler(mContext, mProgress, mDownloadDialog, this.mSavePath, mHashMap);
@@ -70,9 +71,8 @@ public class DownloadApkThread implements Runnable {
                 // 创建连接
                 HttpURLConnection conn = (HttpURLConnection) url.openConnection();
 
-                if(this.options.getString("authType").equals("basic")){
-                    String encoded = Base64.encodeToString((this.options.getString("username")+":"+this.options.getString("password")).getBytes(StandardCharsets.UTF_8), Base64.DEFAULT);  //Java 8
-                    conn.setRequestProperty("Authorization", "Basic "+encoded);
+                if(this.authentication.hasCredentials()){
+                    conn.setRequestProperty("Authorization", this.authentication.getEncodedAuthorization());
                 }
 
                 conn.connect();
@@ -116,8 +116,6 @@ public class DownloadApkThread implements Runnable {
         } catch (MalformedURLException e) {
             e.printStackTrace();
         } catch (IOException e) {
-            e.printStackTrace();
-        } catch (JSONException e){
             e.printStackTrace();
         }
 

--- a/src/android/DownloadHandler.java
+++ b/src/android/DownloadHandler.java
@@ -15,6 +15,8 @@ import android.support.v4.content.FileProvider;
 import java.io.File;
 import java.util.HashMap;
 
+import org.apache.cordova.LOG;
+
 /**
  * Created by LuoWen on 2015/12/14.
  */
@@ -84,20 +86,31 @@ public class DownloadHandler extends Handler {
      * 安装APK文件
      */
     private void installApk() {
+        LOG.d(TAG, "Installing APK");
+
         File apkFile = new File(mSavePath, mHashMap.get("name"));
         if (!apkFile.exists()) {
+            LOG.e(TAG, "Could not find APK: " + mHashMap.get("name"));
             return;
         }
+
+        LOG.d(TAG, "APK Filename: " + apkFile.toString());
+
         // 通过Intent安装APK文件
-        Intent i = new Intent(Intent.ACTION_VIEW);
-        i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        if(Build.VERSION.SDK_INT >= 24){
-            i.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-            Uri uri = FileProvider.getUriForFile(mContext, "com.vaenow.appupdate.android.provider", apkFile);
-            i.setDataAndType(uri, "application/vnd.android.package-archive");
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.N){
+            LOG.d(TAG, "Build SDK Greater than or equal to Nougat");
+            Uri apkUri = FileProvider.getUriForFile(mContext, "com.vaenow.appupdate.android.provider", apkFile);
+            Intent i = new Intent(Intent.ACTION_INSTALL_PACKAGE);
+            i.setData(apkUri);
+            i.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            mContext.startActivity(i);
         }else{
+            LOG.d(TAG, "Build SDK less than Nougat");
+            Intent i = new Intent(Intent.ACTION_VIEW);
+            i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             i.setDataAndType(Uri.parse("file://" + apkFile.toString()), "application/vnd.android.package-archive");
+            mContext.startActivity(i);
         }
-        mContext.startActivity(i);
+
     }
 }

--- a/www/AppUpdate.js
+++ b/www/AppUpdate.js
@@ -1,7 +1,33 @@
 var exec = require('cordova/exec');
 
-exports.checkAppUpdate = function(success, error, updateUrl, options) {
-    updateUrl = updateUrl ? updateUrl : '';
+/**
+ * Check if there is an update to the App.
+ * 
+ * This function can be called in three ways:
+ * 1. checkAppUpdate(updateUrl)
+ * 2. checkAppUpdate(updateUrl, options)
+ * 3. checkAppUpdate(sucessCallback, errorCallback, updateUrl, options)
+ * 
+ * @param successOrUrl The success callback or the URL where the update data  is located
+ * @param errorOrOptions The function called on error or the authentication options
+ * @param updateUrl The URL where the update data is located
+ * @param options An object that may contain the authentication options
+ */
+exports.checkAppUpdate = function(successOrUrl, errorOrOptions, updateUrl, options) {
+    // If the update URL hasnt been set in the updateUrl then assume no callbacks passed
+    var successCallback = updateUrl ? successOrUrl : null;
+    var errorCallback = updateUrl ? errorOrOptions : null;
+    
+    // This handles case 2, where there is an updateURL and options set
+    if ( !updateUrl && typeof errorOrOptions === 'object' ) {
+        options = errorOrOptions;
+    }
+    
+    // If there is no updateUrl then assume that the URL is the first paramater
+    updateUrl = updateUrl ? updateUrl : successOrUrl;
+    
     options = options ? options : {};
-    exec(success, error, "AppUpdate", "checkAppUpdate",  [updateUrl, options]);
+    
+    
+    exec(successCallback, errorCallback, "AppUpdate", "checkAppUpdate",  [updateUrl, options]);
 };


### PR DESCRIPTION
This pull request mainly fixes an issue when targeting Nougat.  

The authorities section in of the provider tag in _plugin.xml_ was set to `"com.vaenow.appupdate.android.provider.${applicationId}"`.  However, in _DownloadHandler.java_, the plugin was calling `com.vaenow.appupdate.android.provider`.

I changed _plugin.xml_.

I also updated the Javascript function to be called without success or error callback functions (to be compatible with ionic-native).



