### PR TITLE
AutoUpdate without prompt: immediate App restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ appUpdate.checkAppUpdate(onSuccess, onFail, updateUrl, {
 })
 ```
 
+- Auto Update without waiting for User Prompt (App AutoUpdate and Restart immediately):
+```js
+appUpdate.checkAppUpdate(onSuccess, onFail, updateUrl, {
+    'skipPrompt' : '1'
+})
+```
+
 ### versionCode
 
 You can simply get the versionCode from typing those code in `Console`

--- a/src/android/UpdateManager.java
+++ b/src/android/UpdateManager.java
@@ -148,10 +148,19 @@ public class UpdateManager {
                 mHandler.sendEmptyMessage(Constants.VERSION_UPDATING);
             } else {
                 LOG.d(TAG, "need update");
+				boolean skipPrompt=false;
+                try {
+                    skipPrompt = this.options.getString("skipPrompt").equals("1") ||  this.options.getString("skipPrompt").toUpperCase().equals("TRUE");
+                } catch (JSONException e){}
                 // 显示提示对话框
-				mHandler.sendEmptyMessage(Constants.DOWNLOAD_CLICK_START);
-                //msgBox.showNoticeDialog(noticeDialogOnClick);
-                //mHandler.sendEmptyMessage(Constants.VERSION_NEED_UPDATE);
+                if (skipPrompt) {
+                    // Skip Prompt, update immediately
+                    mHandler.sendEmptyMessage(Constants.DOWNLOAD_CLICK_START);
+                } else {
+                    // Wait for user prompt before updating
+                    msgBox.showNoticeDialog(noticeDialogOnClick);
+                    mHandler.sendEmptyMessage(Constants.VERSION_NEED_UPDATE);
+                }
             }
         } else {
             mHandler.sendEmptyMessage(Constants.VERSION_UP_TO_UPDATE);

--- a/src/android/UpdateManager.java
+++ b/src/android/UpdateManager.java
@@ -149,8 +149,9 @@ public class UpdateManager {
             } else {
                 LOG.d(TAG, "need update");
                 // 显示提示对话框
-                msgBox.showNoticeDialog(noticeDialogOnClick);
-                mHandler.sendEmptyMessage(Constants.VERSION_NEED_UPDATE);
+				mHandler.sendEmptyMessage(Constants.DOWNLOAD_CLICK_START);
+                //msgBox.showNoticeDialog(noticeDialogOnClick);
+                //mHandler.sendEmptyMessage(Constants.VERSION_NEED_UPDATE);
             }
         } else {
             mHandler.sendEmptyMessage(Constants.VERSION_UP_TO_UPDATE);


### PR DESCRIPTION
With this modification the app is able to AutoUpdate and Restart without the prompt "The App needs to be updated", that is without the need for the user to tap on button "Update".
The App AutoUpdates and Restarts by itself, without any user interaction.
