### PR TITLE
Prevent INSTALL_FAILED_CONFLICTING_PROVIDER error again!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# cordova-plugin-app-update-fork
+Temporary fork of cordova-plugin-app-update until the following pull-request is integrated.
+
+https://github.com/vaenow/cordova-plugin-app-update/pull/79
+
+Everything below is from the original README.md
 
 
 ![travis](https://travis-ci.org/vaenow/cordova-plugin-app-update.svg?branch=master)  

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "cordova-plugin-app-update",
+  "name": "cordova-plugin-app-update-fork",
   "version": "1.4.14",
-  "description": "Cordova App Update",
+  "description": "Cordova App Update (Temporary Fork)",
   "cordova": {
-    "id": "cordova-plugin-app-update",
+    "id": "cordova-plugin-app-update-fork",
     "platforms": [
       "android"
     ]
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vaenow/cordova-plugin-app-update.git"
+    "url": "git+https://github.com/loban/cordova-plugin-app-update.git"
   },
   "keywords": [
     "cordova",
@@ -22,20 +22,23 @@
     "ecosystem:cordova",
     "cordova-android"
   ],
-  "author": "vaenow",
+  "author": {
+    "name": "Loban Rahman",
+    "email": "loban.rahman@gmail.com",
+  },
   "license": "MIT",
   "scripts": {
     "test": "npm run jshint",
     "jshint": "node node_modules/jshint/bin/jshint www && node node_modules/jshint/bin/jshint src"
   },
   "bugs": {
-    "url": "https://github.com/vaenow/cordova-plugin-app-update/issues"
+    "url": "https://github.com/loban/cordova-plugin-app-update/issues"
   },
   "scripts": {
     "test": "npm run jshint",
     "jshint": "node node_modules/jshint/bin/jshint www && node node_modules/jshint/bin/jshint src && node node_modules/jshint/bin/jshint tests"
   },
-  "homepage": "https://github.com/vaenow/cordova-plugin-app-update#readme",
+  "homepage": "https://github.com/loban/cordova-plugin-app-update#readme",
   "devDependencies": {
     "jshint": "^2.6.0"
   }

--- a/package.json
+++ b/package.json
@@ -24,13 +24,9 @@
   ],
   "author": {
     "name": "Loban Rahman",
-    "email": "loban.rahman@gmail.com",
+    "email": "loban.rahman@gmail.com"
   },
   "license": "MIT",
-  "scripts": {
-    "test": "npm run jshint",
-    "jshint": "node node_modules/jshint/bin/jshint www && node node_modules/jshint/bin/jshint src"
-  },
   "bugs": {
     "url": "https://github.com/loban/cordova-plugin-app-update/issues"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-app-update-fork",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "description": "Cordova App Update (Temporary Fork)",
   "cordova": {
     "id": "cordova-plugin-app-update-fork",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-app-update",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Cordova App Update",
   "cordova": {
     "id": "cordova-plugin-app-update",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-app-update",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Cordova App Update",
   "cordova": {
     "id": "cordova-plugin-app-update",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-    id="cordova-plugin-app-update" version="1.4.4">
+    id="cordova-plugin-app-update" version="1.4.5">
     <name>AppUpdate</name>
     <description>Cordova App Update</description>
     <license>Apache 2.0</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-    id="cordova-plugin-app-update" version="1.4.14">
-    <name>AppUpdate</name>
-    <description>Cordova App Update</description>
+    id="cordova-plugin-app-update-fork" version="1.4.14">
+    <name>AppUpdateFork</name>
+    <description>Cordova App Update (Temporary Fork)</description>
     <license>Apache 2.0</license>
     <keywords>cordova,update,app,auto,updater</keywords>
     <dependency id="cordova-plugin-appversion" version="1.0.0" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-    id="cordova-plugin-app-update" version="1.4.5">
+    id="cordova-plugin-app-update" version="1.4.6">
     <name>AppUpdate</name>
     <description>Cordova App Update</description>
     <license>Apache 2.0</license>


### PR DESCRIPTION
I had previously made a pull request to fix this problem, which occurs if you try to install two cordova apps with this plugin, due to a conflicting hard-coded provider name specified in plugin.xml. The solution was to make the provider name dynamic (using applicationId).

However, several commits later, the fix was removed due to additional java code that could not handle the dynamic provider name. This patch both re-applies the dynamic provider, and adds java code to handle it.

Cheers!