### PR TITLE
Prevent INSTALL_FAILED_CONFLICTING_PROVIDER error again!

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -26,7 +26,7 @@
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
              <provider
                 android:name="com.vaenow.appupdate.android.GenericFileProvider"
-                android:authorities="com.vaenow.appupdate.android.provider"
+                android:authorities="${applicationId}.appupdate.provider"
                 android:exported="false"
                 android:grantUriPermissions="true">
                 <meta-data

--- a/src/android/DownloadHandler.java
+++ b/src/android/DownloadHandler.java
@@ -1,5 +1,7 @@
 package com.vaenow.appupdate.android;
 
+import org.apache.cordova.BuildHelper;
+
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -99,7 +101,8 @@ public class DownloadHandler extends Handler {
         // 通过Intent安装APK文件
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.N){
             LOG.d(TAG, "Build SDK Greater than or equal to Nougat");
-            Uri apkUri = FileProvider.getUriForFile(mContext, "com.vaenow.appupdate.android.provider", apkFile);
+            String applicationId = (String) BuildHelper.getBuildConfigValue(cordova.getActivity(), "APPLICATION_ID");
+            Uri apkUri = FileProvider.getUriForFile(mContext, applicationId + ".appupdate.provider", apkFile);
             Intent i = new Intent(Intent.ACTION_INSTALL_PACKAGE);
             i.setData(apkUri);
             i.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);

--- a/src/android/DownloadHandler.java
+++ b/src/android/DownloadHandler.java
@@ -3,6 +3,7 @@ package com.vaenow.appupdate.android;
 import org.apache.cordova.BuildHelper;
 
 import android.app.AlertDialog;
+import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -101,7 +102,7 @@ public class DownloadHandler extends Handler {
         // 通过Intent安装APK文件
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.N){
             LOG.d(TAG, "Build SDK Greater than or equal to Nougat");
-            String applicationId = (String) BuildHelper.getBuildConfigValue(cordova.getActivity(), "APPLICATION_ID");
+            String applicationId = (String) BuildHelper.getBuildConfigValue((Activity) mContext, "APPLICATION_ID");
             Uri apkUri = FileProvider.getUriForFile(mContext, applicationId + ".appupdate.provider", apkFile);
             Intent i = new Intent(Intent.ACTION_INSTALL_PACKAGE);
             i.setData(apkUri);


### PR DESCRIPTION
I had previously made a pull request to fix this problem, which occurs if you try to install two cordova apps with this plugin, due to a conflicting hard-coded provider name specified in plugin.xml. The solution was to make the provider name dynamic (using applicationId).

However, several commits later, the fix was removed due to additional java code that could not handle the dynamic provider name. This patch both re-applies the dynamic provider, and adds java code to handle it.

This fixes issue #67.

I had previously made an erroneous pull request #79 from the wrong branch (which I have now closed). This pull request is the correct one!