### PR TITLE
Enable usage in Android 8+

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ versionName | versionCode
     int NO_SUCH_METHOD = 501;
 
     /**
+     * Permissions
+     */
+    int PERMISSION_DENIED = 601;
+
+    /**
      * 未知错误
      */
     int UNKNOWN_ERROR = 901;

--- a/package.json
+++ b/package.json
@@ -24,10 +24,6 @@
   ],
   "author": "vaenow",
   "license": "MIT",
-  "scripts": {
-    "test": "npm run jshint",
-    "jshint": "node node_modules/jshint/bin/jshint www && node node_modules/jshint/bin/jshint src"
-  },
   "bugs": {
     "url": "https://github.com/vaenow/cordova-plugin-app-update/issues"
   },

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,8 +19,9 @@
 
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.INTERNET" />
+            <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-            <uses-permission android:name="android.permission.MOUNT_UNMOUNT_FILESYSTEMS"/>
+            <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">

--- a/src/android/CheckAppUpdate.java
+++ b/src/android/CheckAppUpdate.java
@@ -2,6 +2,7 @@ package com.vaenow.appupdate.android;
 
 import android.app.Activity;
 import android.Manifest;
+import android.content.pm.PackageManager;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
@@ -74,7 +75,7 @@ public class CheckAppUpdate extends CordovaPlugin {
     public void onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults) throws JSONException {
         for (int result:grantResults) {
             if (result == PackageManager.PERMISSION_DENIED) {
-                callbackContext.error(Utils.makeJSON(Constants.PERMISSION_DENIED, "Necessary permissions denied"));
+                getUpdateManager().permissionsDenied();
                 return;
             }
         }

--- a/src/android/CheckAppUpdate.java
+++ b/src/android/CheckAppUpdate.java
@@ -5,6 +5,8 @@ import android.Manifest;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.PluginResult;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 
@@ -14,42 +16,70 @@ import org.json.JSONException;
 public class CheckAppUpdate extends CordovaPlugin {
     public static final String TAG = "CheckAppUpdate";
 
-    private UpdateManager updateManager = null;
-
-    // Storage Permissions
-    private static final int REQUEST_EXTERNAL_STORAGE = 1;
-    private static String[] PERMISSIONS_STORAGE = {
-        Manifest.permission.READ_EXTERNAL_STORAGE,
-        Manifest.permission.WRITE_EXTERNAL_STORAGE };
-
     @Override
-    public boolean execute(String action, JSONArray args, CallbackContext callbackContext)
-            throws JSONException {
-
+    public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
         if (action.equals("checkAppUpdate")) {
-            verifyStoragePermissions();
-            getUpdateManager(args, callbackContext).checkUpdate();
+            getUpdateManager().options(args, callbackContext);
+            if (verifyPermissions())
+                getUpdateManager().checkUpdate();
             return true;
         }
-        callbackContext.error(Utils.makeJSON(Constants.NO_SUCH_METHOD, "no such method: " + action));
+
+        callbackContext.error(Utils.makeJSON(Constants.NO_SUCH_METHOD, "No such method: " + action));
         return false;
     }
 
-    public UpdateManager getUpdateManager(JSONArray args, CallbackContext callbackContext)
-            throws JSONException {
+    //////////
+    // Update Manager
+    //////////
 
-        if (this.updateManager == null) {
-            this.updateManager = new UpdateManager(this.cordova.getActivity(), this.cordova);
-        }
+    // UpdateManager singleton
+    private UpdateManager updateManager = null;
 
-        return this.updateManager.options(args, callbackContext);
+    // Generate or retrieve the UpdateManager singleton
+    public UpdateManager getUpdateManager() throws JSONException {
+        if (updateManager == null)
+            updateManager = new UpdateManager(cordova.getActivity(), cordova);
+
+        return updateManager;
     }
 
-    public void verifyStoragePermissions() {
-        // Check if we have write permission
-        // and if we don't prompt the user
-        if (!cordova.hasPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-            cordova.requestPermissions(this, REQUEST_EXTERNAL_STORAGE, PERMISSIONS_STORAGE);
+    //////////
+    // Permissions
+    //////////
+
+    // Necessary permissions for this plugin.
+    private static final int PERMISSIONS_REQUEST_CODE = 0;
+    private static String[] PERMISSIONS = {
+        Manifest.permission.INTERNET,
+        Manifest.permission.READ_EXTERNAL_STORAGE,
+        Manifest.permission.WRITE_EXTERNAL_STORAGE,
+        Manifest.permission.REQUEST_INSTALL_PACKAGES
+    };
+
+    // Prompt user for all necessary permissions if we don't already have them all.
+    public void verifyPermission() {
+        boolean hasAllPermissions = true;
+        for (String permission:PERMISSIONS)
+            hasAllPermissions = hasAllPermissions && cordova.hasPermission(permission);
+
+        if (hasAllPermissions)
+            return true;
+
+        cordova.requestPermissions(this, PERMISSIONS_REQUEST_CODE, PERMISSIONS);
+        return false;
+    }
+
+    // React to user's response to our request for all necessary permissions.
+    public void onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults) throws JSONException {
+        for (int result:grantResults) {
+            if (result == PackageManager.PERMISSION_DENIED) {
+                callbackContext.error(Utils.makeJSON(Constants.PERMISSION_DENIED, "Necessary permissions denied"));
+                return;
+            }
         }
+
+        if (requestCode == PERMISSIONS_REQUEST_CODE)
+            getUpdateManager().checkUpdate();
     }
 }

--- a/src/android/CheckAppUpdate.java
+++ b/src/android/CheckAppUpdate.java
@@ -59,7 +59,7 @@ public class CheckAppUpdate extends CordovaPlugin {
     };
 
     // Prompt user for all necessary permissions if we don't already have them all.
-    public void verifyPermission() {
+    public boolean verifyPermissions() {
         boolean hasAllPermissions = true;
         for (String permission:PERMISSIONS)
             hasAllPermissions = hasAllPermissions && cordova.hasPermission(permission);

--- a/src/android/Constants.java
+++ b/src/android/Constants.java
@@ -35,7 +35,11 @@ public interface Constants {
      * 没有相应的方法
      */
     int NO_SUCH_METHOD = 501;
-    int PERMISSION_DENIED = 502;
+
+    /**
+     * Permissions
+     */
+    int PERMISSION_DENIED = 601;
 
     /**
      * 未知错误

--- a/src/android/Constants.java
+++ b/src/android/Constants.java
@@ -35,6 +35,7 @@ public interface Constants {
      * 没有相应的方法
      */
     int NO_SUCH_METHOD = 501;
+    int PERMISSION_DENIED = 502;
 
     /**
      * 未知错误

--- a/src/android/UpdateManager.java
+++ b/src/android/UpdateManager.java
@@ -133,6 +133,15 @@ public class UpdateManager {
     }
 
     /**
+     * Permissions denied
+     */
+    public void permissionsDenied() {
+        LOG.d(TAG, "permissionsDenied..");
+
+        callbackContext.error(Utils.makeJSON(Constants.PERMISSION_DENIED, "Necessary permissions denied"));
+    }
+
+    /**
      * 对比版本号
      */
     private void compareVersions() {

--- a/src/android/UpdateManager.java
+++ b/src/android/UpdateManager.java
@@ -135,10 +135,10 @@ public class UpdateManager {
     /**
      * Permissions denied
      */
-    public void permissionsDenied() {
+    public void permissionDenied(String errMsg) {
         LOG.d(TAG, "permissionsDenied..");
 
-        callbackContext.error(Utils.makeJSON(Constants.PERMISSION_DENIED, "Necessary permissions denied"));
+        callbackContext.error(Utils.makeJSON(Constants.PERMISSION_DENIED, errMsg));
     }
 
     /**


### PR DESCRIPTION
Android version 8 and above require new permissions in order to install external APKs. This patch does the following things:

- For Android version 8 and above, check if necessary permissions are available, and if not, launch the activity (Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES) where the user can enable the appropriate permission.
- For previous Android versions, check if necessary permissions are available, and if not, launch the activity (Settings.ACTION_SECURITY_SETTINGS) where the user can enable the appropriate permission.
- Request other necessary permissions from the user.
