### PR TITLE
Add two optional options that are used to skip dialogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,14 @@ Just clone and install this demo.
 `cordova plugin add cordova-plugin-app-update --save`
 
 # Usage
- - Simple:
+
+- Simple:
 ```js
 var updateUrl = "http://192.168.0.1/version.xml";
 window.AppUpdate.checkAppUpdate(onSuccess, onFail, updateUrl);
 ```
- - Verbose
+
+- Verbose
 ```js
 var appUpdate = cordova.require('cordova-plugin-app-update.AppUpdate');
 var updateUrl = "http://192.168.0.1/version.xml";
@@ -51,6 +53,14 @@ appUpdate.checkAppUpdate(onSuccess, onFail, updateUrl, {
     'authType' : 'basic',
     'username' : 'test',
     'password' : 'test'
+})
+```
+
+- Skip dialog boxes
+```js
+appUpdate.checkAppUpdate(onSuccess, onFail, updateUrl, {
+    'skipPromptDialog' : true,
+    'skipProgressDialog' : true
 })
 ```
 

--- a/src/android/DownloadHandler.java
+++ b/src/android/DownloadHandler.java
@@ -69,13 +69,14 @@ public class DownloadHandler extends Handler {
     }
 
     public void updateMsgDialog() {
-        mDownloadDialog.getButton(DialogInterface.BUTTON_NEGATIVE).setVisibility(View.GONE); //Update in background
-        mDownloadDialog.getButton(DialogInterface.BUTTON_NEUTRAL).setVisibility(View.VISIBLE); //Install Manually
-        mDownloadDialog.getButton(DialogInterface.BUTTON_POSITIVE).setVisibility(View.VISIBLE); //Download Again
-
         mDownloadDialog.setTitle(msgHelper.getString(MsgHelper.DOWNLOAD_COMPLETE_TITLE));
-        mDownloadDialog.getButton(DialogInterface.BUTTON_NEUTRAL)
-                .setOnClickListener(downloadCompleteOnClick);
+        if (mDownloadDialog.isShowing()) {
+            mDownloadDialog.getButton(DialogInterface.BUTTON_NEGATIVE).setVisibility(View.GONE); //Update in background
+            mDownloadDialog.getButton(DialogInterface.BUTTON_NEUTRAL).setVisibility(View.VISIBLE); //Install Manually
+            mDownloadDialog.getButton(DialogInterface.BUTTON_POSITIVE).setVisibility(View.VISIBLE); //Download Again
+
+            mDownloadDialog.getButton(DialogInterface.BUTTON_NEUTRAL).setOnClickListener(downloadCompleteOnClick);
+        }
     }
 
     private OnClickListener downloadCompleteOnClick = new OnClickListener() {

--- a/src/android/MsgBox.java
+++ b/src/android/MsgBox.java
@@ -61,7 +61,8 @@ public class MsgBox {
      */
     public Map<String, Object> showDownloadDialog(OnClickListener onClickListenerNeg,
                                                   OnClickListener onClickListenerPos,
-                                                  OnClickListener onClickListenerNeu) {
+                                                  OnClickListener onClickListenerNeu,
+                                                  boolean showDialog) {
         if (downloadDialog == null) {
             LOG.d(TAG, "showDownloadDialog");
 
@@ -84,14 +85,16 @@ public class MsgBox {
             downloadDialog = builder.create();
         }
 
-        if (!downloadDialog.isShowing()) downloadDialog.show();
+        if (showDialog && !downloadDialog.isShowing()) downloadDialog.show();
 
         downloadDialog.setTitle(msgHelper.getString(MsgHelper.UPDATING));
-        downloadDialog.getButton(DialogInterface.BUTTON_NEGATIVE).setVisibility(View.VISIBLE); //Update in background
-        downloadDialog.getButton(DialogInterface.BUTTON_NEUTRAL).setVisibility(View.GONE); //Install Manually
-        downloadDialog.getButton(DialogInterface.BUTTON_POSITIVE).setVisibility(View.GONE); //Download Again
-
         downloadDialog.setCanceledOnTouchOutside(false);// 设置点击屏幕Dialog不消失
+        if (downloadDialog.isShowing()) {
+            downloadDialog.getButton(DialogInterface.BUTTON_NEGATIVE).setVisibility(View.VISIBLE); //Update in background
+            downloadDialog.getButton(DialogInterface.BUTTON_NEUTRAL).setVisibility(View.GONE); //Install Manually
+            downloadDialog.getButton(DialogInterface.BUTTON_POSITIVE).setVisibility(View.GONE); //Download Again
+        }
+
         Map<String, Object> ret = new HashMap<String, Object>();
         ret.put("dialog", downloadDialog);
         ret.put("progress", downloadDialogProgress);

--- a/src/android/UpdateManager.java
+++ b/src/android/UpdateManager.java
@@ -140,17 +140,31 @@ public class UpdateManager {
         int versionCodeLocal = version.getLocal();
         int versionCodeRemote = version.getRemote();
 
+        boolean skipPromptDialog = false;
+        try {
+            skipPromptDialog = options.getBoolean("skipPromptDialog");
+        } catch (JSONException e) {}
+
+        boolean skipProgressDialog = false;
+        try {
+            skipProgressDialog = options.getBoolean("skipProgressDialog");
+        } catch (JSONException e) {}
+
         //比对版本号
         //检查软件是否有更新版本
         if (versionCodeLocal < versionCodeRemote) {
             if (isDownloading) {
-                msgBox.showDownloadDialog(null, null, null);
+                msgBox.showDownloadDialog(null, null, null, !skipProgressDialog);
                 mHandler.sendEmptyMessage(Constants.VERSION_UPDATING);
             } else {
                 LOG.d(TAG, "need update");
-                // 显示提示对话框
-                msgBox.showNoticeDialog(noticeDialogOnClick);
-                mHandler.sendEmptyMessage(Constants.VERSION_NEED_UPDATE);
+                if (skipPromptDialog) {
+                    mHandler.sendEmptyMessage(Constants.DOWNLOAD_CLICK_START);
+                } else {
+                    // 显示提示对话框
+                    msgBox.showNoticeDialog(noticeDialogOnClick);
+                    mHandler.sendEmptyMessage(Constants.VERSION_NEED_UPDATE);
+                }
             }
         } else {
             mHandler.sendEmptyMessage(Constants.VERSION_UP_TO_UPDATE);
@@ -169,11 +183,19 @@ public class UpdateManager {
 
     private void emitNoticeDialogOnClick() {
         isDownloading = true;
+
+        boolean skipProgressDialog = false;
+        try {
+            skipProgressDialog = options.getBoolean("skipProgressDialog");
+        } catch (JSONException e) {}
+
         // 显示下载对话框
         Map<String, Object> ret = msgBox.showDownloadDialog(
                 downloadDialogOnClickNeg,
                 downloadDialogOnClickPos,
-                downloadDialogOnClickNeu);
+                downloadDialogOnClickNeu,
+                !skipProgressDialog);
+
         // 下载文件
         downloadApk((AlertDialog) ret.get("dialog"), (ProgressBar) ret.get("progress"));
     }


### PR DESCRIPTION
Users of the plugin (including me) may want to create a seamless experience for their users and not show any dialog prompts. This patch allows two additional options when calling the checkAppUpdate() function.

- **skipPromptDialog** (when true, then the plugin immediately and silently starts downloading an update when found)
- **skipProgressDialog** (when true, then the plugin does not show the progress bar dialog, and instead does it in the background)

This was inspired by pull request https://github.com/vaenow/cordova-plugin-app-update/pull/78, and incorporates the request to make it an optional feature.