### PR TITLE
Add permission for android 8

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -20,6 +20,7 @@
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.INTERNET" />
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+            <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
             <uses-permission android:name="android.permission.MOUNT_UNMOUNT_FILESYSTEMS"/>
         </config-file>
 


### PR DESCRIPTION
In android 8 you need add a permission in plugin.xml 

> cordova-plugin-app-update

 to worked fine  on smartphone.
I added directly into androidmanifest.xml and work well for myself.

`<uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />`
