### PR TITLE
Fix build with cordova-android@7

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -35,21 +35,21 @@
             </provider>
         </config-file>
 
-        <source-file src="src/android/AuthenticationOptions.java" target-dir="src/com/vaenow/appupdate"/>
-        <source-file src="src/android/CheckAppUpdate.java" target-dir="src/com/vaenow/appupdate"/>
-        <source-file src="src/android/CheckUpdateThread.java" target-dir="src/com/vaenow/appupdate"/>
-        <source-file src="src/android/Constants.java" target-dir="src/com/vaenow/appupdate"/>
-        <source-file src="src/android/DownloadApkThread.java" target-dir="src/com/vaenow/appupdate"/>
-        <source-file src="src/android/DownloadHandler.java" target-dir="src/com/vaenow/appupdate"/>
-        <source-file src="src/android/GenericFileProvider.java" target-dir="src/com/vaenow/appupdate"/>
-        <source-file src="src/android/GetRemoteXmlThread.java" target-dir="src/com/vaenow/appupdate"/>
-        <source-file src="src/android/MsgBox.java" target-dir="src/com/vaenow/appupdate"/>
-        <source-file src="src/android/MsgHelper.java" target-dir="src/com/vaenow/appupdate"/>
-        <source-file src="src/android/ParseXmlService.java" target-dir="src/com/vaenow/appupdate"/>
-        <source-file src="src/android/UIValues.java" target-dir="src/com/vaenow/appupdate"/>
-        <source-file src="src/android/UpdateManager.java" target-dir="src/com/vaenow/appupdate"/>
-        <source-file src="src/android/Utils.java" target-dir="src/com/vaenow/appupdate"/>
-        <source-file src="src/android/Version.java" target-dir="src/com/vaenow/appupdate"/>
+        <source-file src="src/android/AuthenticationOptions.java" target-dir="src/com/vaenow/appupdate/android"/>
+        <source-file src="src/android/CheckAppUpdate.java" target-dir="src/com/vaenow/appupdate/android"/>
+        <source-file src="src/android/CheckUpdateThread.java" target-dir="src/com/vaenow/appupdate/android"/>
+        <source-file src="src/android/Constants.java" target-dir="src/com/vaenow/appupdate/android"/>
+        <source-file src="src/android/DownloadApkThread.java" target-dir="src/com/vaenow/appupdate/android"/>
+        <source-file src="src/android/DownloadHandler.java" target-dir="src/com/vaenow/appupdate/android"/>
+        <source-file src="src/android/GenericFileProvider.java" target-dir="src/com/vaenow/appupdate/android"/>
+        <source-file src="src/android/GetRemoteXmlThread.java" target-dir="src/com/vaenow/appupdate/android"/>
+        <source-file src="src/android/MsgBox.java" target-dir="src/com/vaenow/appupdate/android"/>
+        <source-file src="src/android/MsgHelper.java" target-dir="src/com/vaenow/appupdate/android"/>
+        <source-file src="src/android/ParseXmlService.java" target-dir="src/com/vaenow/appupdate/android"/>
+        <source-file src="src/android/UIValues.java" target-dir="src/com/vaenow/appupdate/android"/>
+        <source-file src="src/android/UpdateManager.java" target-dir="src/com/vaenow/appupdate/android"/>
+        <source-file src="src/android/Utils.java" target-dir="src/com/vaenow/appupdate/android"/>
+        <source-file src="src/android/Version.java" target-dir="src/com/vaenow/appupdate/android"/>
 
         <source-file src="res/values/appupdate_strings.xml" target-dir="res/values"/>
         <source-file src="res/values-en/appupdate_strings.xml" target-dir="res/values-en"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -35,7 +35,22 @@
             </provider>
         </config-file>
 
-        <source-file src="src/android" target-dir="src/com/vaenow/appupdate"/>
+        <source-file src="src/android/AuthenticationOptions.java" target-dir="src/com/vaenow/appupdate"/>
+        <source-file src="src/android/CheckAppUpdate.java" target-dir="src/com/vaenow/appupdate"/>
+        <source-file src="src/android/CheckUpdateThread.java" target-dir="src/com/vaenow/appupdate"/>
+        <source-file src="src/android/Constants.java" target-dir="src/com/vaenow/appupdate"/>
+        <source-file src="src/android/DownloadApkThread.java" target-dir="src/com/vaenow/appupdate"/>
+        <source-file src="src/android/DownloadHandler.java" target-dir="src/com/vaenow/appupdate"/>
+        <source-file src="src/android/GenericFileProvider.java" target-dir="src/com/vaenow/appupdate"/>
+        <source-file src="src/android/GetRemoteXmlThread.java" target-dir="src/com/vaenow/appupdate"/>
+        <source-file src="src/android/MsgBox.java" target-dir="src/com/vaenow/appupdate"/>
+        <source-file src="src/android/MsgHelper.java" target-dir="src/com/vaenow/appupdate"/>
+        <source-file src="src/android/ParseXmlService.java" target-dir="src/com/vaenow/appupdate"/>
+        <source-file src="src/android/UIValues.java" target-dir="src/com/vaenow/appupdate"/>
+        <source-file src="src/android/UpdateManager.java" target-dir="src/com/vaenow/appupdate"/>
+        <source-file src="src/android/Utils.java" target-dir="src/com/vaenow/appupdate"/>
+        <source-file src="src/android/Version.java" target-dir="src/com/vaenow/appupdate"/>
+
         <source-file src="res/values/appupdate_strings.xml" target-dir="res/values"/>
         <source-file src="res/values-en/appupdate_strings.xml" target-dir="res/values-en"/>
         <source-file src="res/values-es/appupdate_strings.xml" target-dir="res/values-es"/>


### PR DESCRIPTION
fixes https://github.com/vaenow/cordova-plugin-app-update/issues/108

based on https://github.com/radiocutfm/cordova-plugin-app-update/commit/caed88112076f6e7d09bf52bd8e102d5a89e0af1

The cause of the issue is that cordova-android@7 maps file paths differently if source-file has `.java` suffix, but that logic fails to pick up directories containing `.java` files. See:
https://github.com/apache/cordova-android/commit/a9e01f43095dfcea35a9d774f1c8a320b8aa6756#diff-4f73e5f70cec312ae82aa7d023e3c88bR39