### PR TITLE
Migration to androidx libs

### DIFF
--- a/src/android/DownloadHandler.java
+++ b/src/android/DownloadHandler.java
@@ -14,7 +14,7 @@ import android.os.Message;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.ProgressBar;
-import android.support.v4.content.FileProvider;
+import androidx.core.content.FileProvider;
 import java.io.File;
 import java.util.HashMap;
 

--- a/src/android/GenericFileProvider.java
+++ b/src/android/GenericFileProvider.java
@@ -1,6 +1,6 @@
 package com.vaenow.appupdate.android;
 
-import android.support.v4.content.FileProvider;
+import androidx.core.content.FileProvider;
 
 /**
  * Created by kalea on 2017/8/23.


### PR DESCRIPTION
Artifacts within the androidx namespace comprise the Android Jetpack libraries. Like the Support Library, libraries in theandroidx namespace ship separately from the Android platform and provide backward compatibility across Android releases.

AndroidX is a major improvement to the original Android Support Library, which is no longer maintained. androidx packages fully replace the Support Library by providing feature parity and new libraries.

Check info: https://developer.android.com/jetpack/androidx

